### PR TITLE
Add services and middleware for API and gRPC support

### DIFF
--- a/Presentation/Program.cs
+++ b/Presentation/Program.cs
@@ -1,10 +1,38 @@
+using Presentation;
+using Presentation.Interfaces;
 using Presentation.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddGrpc();
 
+builder.Services.AddControllers();
+builder.Services.AddOpenApi();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddCors(option => { option.AddPolicy("AllowAll", policy => policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()); });
+
+builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddGrpcClient<AccountGrpcService.AccountGrpcServiceClient>(option =>
+{
+    option.Address = new Uri(builder.Configuration["Providers:AccountServiceProvider"]!);
+});
+
 var app = builder.Build();
+app.MapOpenApi();
+app.UseSwagger();
+app.UseSwaggerUI(option =>
+{
+    option.SwaggerEndpoint("/swagger/v1/swagger.json", "Ventixe AuthServiceProvider API");
+    option.RoutePrefix = string.Empty;
+});
+
 app.MapGrpcService<AuthService>();
 app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
 
+app.UseHsts();
+app.UseHttpsRedirection();
+app.UseCors("AllowAll");
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
 app.Run();


### PR DESCRIPTION
This commit introduces OpenAPI and Swagger for API documentation, implements a CORS policy to allow all origins, and registers an authentication service. It also sets up a gRPC client for account services, maps the gRPC service and controllers, and configures HTTPS redirection and HSTS for improved security.