### PR TITLE
Rename VerificationCode to Code in VerifyForm

### DIFF
--- a/Presentation/Models/VerifyForm.cs
+++ b/Presentation/Models/VerifyForm.cs
@@ -3,5 +3,5 @@
 public class VerifyForm
 {
     public string Email { get; set; } = null!;
-    public string VerificationCode { get; set; } = null!;
+    public string Code { get; set; } = null!;
 }


### PR DESCRIPTION
Updated VerifyForm to rename `VerificationCode` to `Code` for better clarity. Modified `VerifyCodeAsync` in `AuthService` to validate the new `Code` property and handle errors more effectively. Improved error messages for network issues and verification failures to enhance user experience.